### PR TITLE
fix: exit code not being bubbled to caller

### DIFF
--- a/src/run-p.ts
+++ b/src/run-p.ts
@@ -7,7 +7,11 @@ import { run } from "./index.js"
 async function runP() {
   try {
     supressMaxListenersExceededWarnings()
-    run(argv.slice(2), true)
+    const outputs = await run(argv.slice(2), true)
+    const exitCcode = Math.max(...outputs.map(x => x.code))
+
+    // Exit the process with the highest exit code.
+    process.exit(exitCcode)
   } catch (error) {
     console.error(error)
   }


### PR DESCRIPTION
## What

If two 'things' are being built with ``run-p``, the highest integer exit code should be bubbled to the caller of ``run-p``

## Why

Currently in our CI for [plasmo](https://github.com/PlasmoHQ/plasmo), builds are failing but the CI passes. This is because ``run-p`` is used for all of our [examples](https://github.com/PlasmoHQ/examples/), and this package is always returning exit code 0 (successful exit code). 